### PR TITLE
Add registration confirmation

### DIFF
--- a/contracts/VestingWallet.sol
+++ b/contracts/VestingWallet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.11;
 
 import "./Ownable.sol";
 import "./Token.sol";
@@ -182,7 +182,7 @@ contract VestingWallet is Ownable, SafeMath {
         uint amountWithdrawable = safeSub(totalAmountVested, vestingSchedule.totalAmountWithdrawn);
         vestingSchedule.totalAmountWithdrawn = totalAmountVested;
 
-        if(amountWithdrawable > 0) {
+        if (amountWithdrawable > 0) {
             require(vestingToken.transfer(msg.sender, amountWithdrawable));
             Withdrawal(msg.sender, amountWithdrawable);
         }

--- a/contracts/VestingWallet.sol
+++ b/contracts/VestingWallet.sol
@@ -39,7 +39,7 @@ contract VestingWallet is Ownable, SafeMath {
         uint totalAmount;
         uint totalAmountWithdrawn;
         address depositor;
-        bool registrationConfirmed;
+        bool isConfirmed;
     }
 
     modifier addressRegistered(address target) {
@@ -56,13 +56,13 @@ contract VestingWallet is Ownable, SafeMath {
 
     modifier vestingScheduleConfirmed(address target) {
         VestingSchedule storage vestingSchedule = schedules[target];
-        require(vestingSchedule.registrationConfirmed);
+        require(vestingSchedule.isConfirmed);
         _;
     }
 
     modifier vestingScheduleNotConfirmed(address target) {
         VestingSchedule storage vestingSchedule = schedules[target];
-        require(!vestingSchedule.registrationConfirmed);
+        require(!vestingSchedule.isConfirmed);
         _;
     }
 
@@ -122,7 +122,7 @@ contract VestingWallet is Ownable, SafeMath {
             totalAmount: _totalAmount,
             totalAmountWithdrawn: 0,
             depositor: _depositor,
-            registrationConfirmed: false
+            isConfirmed: false
         });
 
         VestingScheduleRegistered(
@@ -157,7 +157,7 @@ contract VestingWallet is Ownable, SafeMath {
         require(vestingSchedule.endTimeInSec == _endTimeInSec);
         require(vestingSchedule.totalAmount == _totalAmount);
 
-        vestingSchedule.registrationConfirmed = true;
+        vestingSchedule.isConfirmed = true;
         require(vestingToken.transferFrom(vestingSchedule.depositor, address(this), _totalAmount));
 
         VestingScheduleConfirmed(
@@ -251,7 +251,7 @@ contract VestingWallet is Ownable, SafeMath {
     }
 
     /// @dev Calculates the total tokens that have been vested for a vesting schedule, assuming the schedule is past the cliff.
-    /// @param vestingSchedule Vesting schedule used to calcculate vested tokens.
+    /// @param vestingSchedule Vesting schedule used to calculate vested tokens.
     /// @return Total tokens vested for a vesting schedule.
     function getTotalAmountVested(VestingSchedule vestingSchedule)
         internal

--- a/contracts/VestingWallet.sol
+++ b/contracts/VestingWallet.sol
@@ -10,11 +10,17 @@ contract VestingWallet is Ownable, SafeMath {
     mapping(address => address) public addressChangeRequests;    // requested address changes
 
     Token vestingToken;
-    uint public currentId = 0;
 
     event VestingScheduleRegistered(
         address indexed registeredAddress,
-        uint id,
+        address depositor,
+        uint startTimeInSec,
+        uint cliffTimeInSec,
+        uint endTimeInSec,
+        uint totalAmount
+    );
+    event VestingScheduleConfirmed(
+        address indexed registeredAddress,
         uint startTimeInSec,
         uint cliffTimeInSec,
         uint endTimeInSec,
@@ -26,23 +32,36 @@ contract VestingWallet is Ownable, SafeMath {
     event AddressChangeConfirmed(address indexed oldRegisteredAddress, address indexed newRegisteredAddress);
 
     struct VestingSchedule {
-        uint id;
         uint startTimeInSec;
         uint cliffTimeInSec;
         uint endTimeInSec;
         uint totalAmount;
         uint totalAmountWithdrawn;
+        address depositor;
+        bool registrationConfirmed;
     }
 
     modifier addressRegistered(address target) {
         VestingSchedule storage vestingSchedule = schedules[target];
-        require(vestingSchedule.id != 0);
+        require(vestingSchedule.depositor != address(0));
         _;
     }
 
     modifier addressNotRegistered(address target) {
         VestingSchedule storage vestingSchedule = schedules[target];
-        require(vestingSchedule.id == 0);
+        require(vestingSchedule.depositor == address(0));
+        _;
+    }
+
+    modifier addressRegistrationConfirmed(address target) {
+        VestingSchedule storage vestingSchedule = schedules[target];
+        require(vestingSchedule.registrationConfirmed);
+        _;
+    }
+
+    modifier addressRegistrationNotConfirmed(address target) {
+        VestingSchedule storage vestingSchedule = schedules[target];
+        require(!vestingSchedule.registrationConfirmed);
         _;
     }
 
@@ -74,14 +93,13 @@ contract VestingWallet is Ownable, SafeMath {
         vestingToken = Token(_vestingToken);
     }
 
-    /// @dev Registers a vesting schedule to an address and deposits necessary tokens.
+    /// @dev Registers a vesting schedule to an address.
     /// @param _addressToRegister The address that is allowed to withdraw vested tokens for this schedule.
     /// @param _depositor Address that will be depositing vesting token.
     /// @param _startTimeInSec The time in seconds that vesting began.
     /// @param _cliffTimeInSec The time in seconds that tokens become withdrawable.
     /// @param _endTimeInSec The time in seconds that vesting ends.
     /// @param _totalAmount The total amount of tokens that the registered address can withdraw by the end of the vesting period.
-    /// @return Success of registration.
     function registerVestingSchedule(
         address _addressToRegister,
         address _depositor,
@@ -92,62 +110,91 @@ contract VestingWallet is Ownable, SafeMath {
     )
         public
         onlyOwner
-        addressNotRegistered(_addressToRegister)
+        addressNotNull(_depositor)
+        addressRegistrationNotConfirmed(_addressToRegister)
         validVestingScheduleTimes(_startTimeInSec, _cliffTimeInSec, _endTimeInSec)
-        returns (bool)
     {
-        currentId = safeAdd(currentId, 1);
         schedules[_addressToRegister] = VestingSchedule({
-            id: currentId,
             startTimeInSec: _startTimeInSec,
             cliffTimeInSec: _cliffTimeInSec,
             endTimeInSec: _endTimeInSec,
             totalAmount: _totalAmount,
-            totalAmountWithdrawn: 0
+            totalAmountWithdrawn: 0,
+            depositor: _depositor,
+            registrationConfirmed: false
         });
-
-        require(vestingToken.transferFrom(_depositor, address(this), _totalAmount));
 
         VestingScheduleRegistered(
             _addressToRegister,
-            currentId,
+            _depositor,
             _startTimeInSec,
             _cliffTimeInSec,
             _endTimeInSec,
             _totalAmount
         );
-        return true;
+    }
+
+    /// @dev Confirms a vesting schedule and deposits necessary tokens. Throws if deposit fails or schedules do not match.
+    /// @param _startTimeInSec The time in seconds that vesting began.
+    /// @param _cliffTimeInSec The time in seconds that tokens become withdrawable.
+    /// @param _endTimeInSec The time in seconds that vesting ends.
+    /// @param _totalAmount The total amount of tokens that the registered address can withdraw by the end of the vesting period.
+    function confirmVestingSchedule(
+        uint _startTimeInSec,
+        uint _cliffTimeInSec,
+        uint _endTimeInSec,
+        uint _totalAmount
+    )
+        public
+        addressRegistered(msg.sender)
+        addressRegistrationNotConfirmed(msg.sender)
+        validVestingScheduleTimes(_startTimeInSec, _cliffTimeInSec, _endTimeInSec)
+    {
+        VestingSchedule storage vestingSchedule = schedules[msg.sender];
+
+        require(vestingSchedule.startTimeInSec == _startTimeInSec);
+        require(vestingSchedule.cliffTimeInSec == _cliffTimeInSec);
+        require(vestingSchedule.endTimeInSec == _endTimeInSec);
+        require(vestingSchedule.totalAmount == _totalAmount);
+
+        vestingSchedule.registrationConfirmed = true;
+        require(vestingToken.transferFrom(vestingSchedule.depositor, address(this), _totalAmount));
+
+        VestingScheduleConfirmed(
+            msg.sender,
+            _startTimeInSec,
+            _cliffTimeInSec,
+            _endTimeInSec,
+            _totalAmount
+        );
     }
 
     /// @dev Allows a registered address to withdraw tokens that have already been vested.
-    /// @return Success of withdrawal.
     function withdraw()
         public
-        addressRegistered(msg.sender)
+        addressRegistrationConfirmed(msg.sender)
         pastCliffTime(msg.sender)
-        returns (bool)
     {
         VestingSchedule storage vestingSchedule = schedules[msg.sender];
 
         uint totalAmountVested = getTotalAmountVested(vestingSchedule);
         uint amountWithdrawable = safeSub(totalAmountVested, vestingSchedule.totalAmountWithdrawn);
         vestingSchedule.totalAmountWithdrawn = totalAmountVested;
-        require(vestingToken.transfer(msg.sender, amountWithdrawable));
 
-        Withdrawal(msg.sender, amountWithdrawable);
-        return true;
+        if(amountWithdrawable > 0) {
+            require(vestingToken.transfer(msg.sender, amountWithdrawable));
+            Withdrawal(msg.sender, amountWithdrawable);
+        }
     }
 
     /// @dev Allows contract owner to terminate a vesting schedule, transfering remaining vested tokens to the registered address and refunding owner with remaining tokens.
     /// @param _addressToEnd Address that is currently registered to the vesting schedule that will be closed.
     /// @param _addressToRefund Address that will receive unvested tokens.
-    /// @return Success of termination.
     function endVesting(address _addressToEnd, address _addressToRefund)
         public
         onlyOwner
-        addressRegistered(_addressToEnd)
+        addressRegistrationConfirmed(_addressToEnd)
         addressNotNull(_addressToRefund)
-        returns (bool)
     {
         VestingSchedule storage vestingSchedule = schedules[_addressToEnd];
 
@@ -167,34 +214,28 @@ contract VestingWallet is Ownable, SafeMath {
         require(amountRefundable == 0 || vestingToken.transfer(_addressToRefund, amountRefundable));
 
         VestingEndedByOwner(_addressToEnd, amountWithdrawable, amountRefundable);
-        return true;
     }
 
     /// @dev Allows a registered address to request an address change.
     /// @param _newRegisteredAddress Desired address to update to.
-    /// @return Success of request.
     function requestAddressChange(address _newRegisteredAddress)
         public
-        addressRegistered(msg.sender)
+        addressRegistrationConfirmed(msg.sender)
+        addressNotRegistered(_newRegisteredAddress)
         addressNotNull(_newRegisteredAddress)
-        returns (bool)
     {
         addressChangeRequests[msg.sender] = _newRegisteredAddress;
-
         AddressChangeRequested(msg.sender, _newRegisteredAddress);
-        return true;
     }
 
     /// @dev Confirm an address change and migrate vesting schedule to new address.
     /// @param _oldRegisteredAddress Current registered address.
     /// @param _newRegisteredAddress Address to migrate vesting schedule to.
-    /// @return Success of address migration.
     function confirmAddressChange(address _oldRegisteredAddress, address _newRegisteredAddress)
         public
         onlyOwner
         pendingAddressChangeRequest(_oldRegisteredAddress)
         addressNotRegistered(_newRegisteredAddress)
-        returns (bool)
     {
         address newRegisteredAddress = addressChangeRequests[_oldRegisteredAddress];
         require(newRegisteredAddress == _newRegisteredAddress);    // prevents race condition
@@ -206,7 +247,6 @@ contract VestingWallet is Ownable, SafeMath {
         delete addressChangeRequests[_oldRegisteredAddress];
 
         AddressChangeConfirmed(_oldRegisteredAddress, _newRegisteredAddress);
-        return true;
     }
 
     /// @dev Calculates the total tokens that have been vested for a vesting schedule, assuming the schedule is past the cliff.

--- a/test/vesting_wallet.ts
+++ b/test/vesting_wallet.ts
@@ -142,7 +142,7 @@ contract('VestingWallet', (accounts: string[]) => {
                 registeredTotalAmount,
                 registeredTotalAmountWithdrawn,
                 registeredDepositor,
-                registrationConfirmed,
+                isConfirmed,
             ] = scheduleArray;
 
             const expectedTotalAmountWithdrawnString = '0';
@@ -152,7 +152,7 @@ contract('VestingWallet', (accounts: string[]) => {
             assert.equal(registeredTotalAmount.toString(), totalAmount.toString());
             assert.equal(registeredTotalAmountWithdrawn.toString(), expectedTotalAmountWithdrawnString);
             assert.equal(registeredDepositor, depositor);
-            assert.equal(registrationConfirmed, false);
+            assert.equal(isConfirmed, false);
         });
 
         it('should register a vesting schedule and log the correct events when called by owner', async () => {
@@ -205,7 +205,7 @@ contract('VestingWallet', (accounts: string[]) => {
                 registeredTotalAmount,
                 registeredTotalAmountWithdrawn,
                 registeredDepositor,
-                registrationConfirmed,
+                isConfirmed,
             ] = scheduleArray;
 
             const expectedTotalAmountWithdrawnString = '0';
@@ -215,7 +215,7 @@ contract('VestingWallet', (accounts: string[]) => {
             assert.equal(registeredTotalAmount.toString(), newTotalAmount.toString());
             assert.equal(registeredTotalAmountWithdrawn.toString(), expectedTotalAmountWithdrawnString);
             assert.equal(registeredDepositor, newDepositor);
-            assert.equal(registrationConfirmed, false);
+            assert.equal(isConfirmed, false);
         });
 
         it('should throw if vesting schedule is already confirmed', async () => {
@@ -387,8 +387,8 @@ contract('VestingWallet', (accounts: string[]) => {
                                                        {from: addressToRegister});
 
             const scheduleArray = await vestingWallet.schedules.call(addressToRegister);
-            const registrationConfirmed = scheduleArray[6];
-            assert.equal(registrationConfirmed, true);
+            const isConfirmed = scheduleArray[6];
+            assert.equal(isConfirmed, true);
 
             const logs = res.logs;
             assert.equal(logs.length, 1);


### PR DESCRIPTION
- Adds a step that requires the registrant to confirm the vesting schedule before it becomes withdraw-able. This makes the flow less prone to typos, and also proves that the registrant has agreed to the vesting terms.
- Removes unnecessary `id` property. 
- The flow now looks like:
1. Owner registers a vesting schedule to a registrant address.
2. Registrant confirms vesting schedule. This also transfers tokens from the `depositor` address to the vesting wallet contract.
3. Registrant can withdraw vested tokens after cliff.
4. Registrant can request an address change after being confirmed.
5. Owner can end the vesting after a a schedule has been confirmed.